### PR TITLE
Use strcmp to compare SKUs

### DIFF
--- a/src/Datapump/Product/ItemHolder.php
+++ b/src/Datapump/Product/ItemHolder.php
@@ -146,7 +146,7 @@ class ItemHolder
                 $sku = $product->get('sku');
                 foreach ($this->products as $p) {
                     /** @var ProductAbstract $p */
-                    if ($p->get('sku') == $sku) {
+                    if (strcmp($p->get('sku'), $sku) === 0) {
                         throw new Exception\ProductSkuAlreadyAdded(
                             sprintf(
                                 'Product with SKU: %s is already added',


### PR DESCRIPTION
This will make the datapump compare SKUs in the same way as recent versions of Magmi.
Previosly SKUs only containing digits with leading zeroes could conflict e.g. 002 and 000002 would be considered equal by the datapump